### PR TITLE
Add emojis and expand poll options for WhatsApp messages

### DIFF
--- a/send_whatsapp.py
+++ b/send_whatsapp.py
@@ -93,8 +93,8 @@ def send_poll(room: str) -> None:
     url = f"{BASE_URL}/messages/poll"
     payload = {
         "to": WHATSAPP_GROUP_ID,
-        "title": f"מנחה ב-13:30, חדר {room}\n\n_ההודעה נשלחה אוטומטית_",
-        "options": ["מגיע", "תקראו לי אם חסר"],
+        "title": f"🕍 מנחה ב-13:30, חדר {room}\n\n_ההודעה נשלחה אוטומטית_",
+        "options": ["✅ מגיע", "📞 תקראו לי אם חסר", "❌ לא מגיע (ישיבה, בבית, חולה, חופש וכו')"],
         "count": 1,
     }
     response = send_request_with_retries(url, payload)
@@ -107,7 +107,7 @@ def send_reminder(room: str) -> None:
     url = f"{BASE_URL}/messages/text"
     payload = {
         "to": WHATSAPP_GROUP_ID,
-        "body": f"תזכורת: אם עוד לא עניתם לסקר - זה הזמן! נתראה ב-13:30, חדר {room}\n\n_ההודעה נשלחה אוטומטית_",
+        "body": f"🔔 תזכורת: אם עוד לא עניתם לסקר - זה הזמן! נתראה ב-13:30, חדר {room}\n\n_ההודעה נשלחה אוטומטית_",
     }
     response = send_request_with_retries(url, payload)
     if response:


### PR DESCRIPTION
- Add synagogue emoji to poll title and bell emoji to reminder
- Expand poll options from 2 to 3 choices with descriptive emojis
- Include "not coming" option with common reasons (meeting, home, sick, vacation)
