### PR TITLE
Add write permissions to weekly dependency upgrade workflow

### DIFF
--- a/.github/workflows/weekly-dep-upgrade.yaml
+++ b/.github/workflows/weekly-dep-upgrade.yaml
@@ -12,6 +12,9 @@ jobs:
   upgrade-dependencies:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Grant contents write permission to enable the workflow to create commits
and push dependency updates automatically.
