### PR TITLE
Add pull-requests write permission to weekly dependency upgrade workflow

### DIFF
--- a/.github/workflows/weekly-dep-upgrade.yaml
+++ b/.github/workflows/weekly-dep-upgrade.yaml
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Grant pull-requests write permission to enable the workflow to create
and manage pull requests for dependency updates.
