### PR TITLE
Add actions write permission to weekly dependency upgrade workflow

### DIFF
--- a/.github/workflows/weekly-dep-upgrade.yaml
+++ b/.github/workflows/weekly-dep-upgrade.yaml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Grant actions permission to enable workflow to manage GitHub Actions
during automated dependency updates.
