### PR TITLE
Update uv version requirement and add checks permission to workflow

### DIFF
--- a/.github/workflows/weekly-dep-upgrade.yaml
+++ b/.github/workflows/weekly-dep-upgrade.yaml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: write
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ ignore = ["COM812", "D203", "D213"]
 typeCheckingMode = "strict"
 
 [tool.uv]
-required-version = ">=0.8.4"
+required-version = ">=0.8.8"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
- Bump uv required version from >=0.8.4 to >=0.8.8
- Add checks: write permission to weekly dependency upgrade workflow
