### PR TITLE
Change Gemini issue triage schedule from hourly to weekly

### DIFF
--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -2,7 +2,7 @@ name: "📋 Gemini Scheduled Issue Triage"
 
 on:
   schedule:
-    - cron: "0 * * * *" # Runs every hour
+    - cron: "5 23 * * 4" # Runs every Thursday at 23:05 UTCFF
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Update cron schedule to run every Thursday at 23:05 UTC instead of every hour to reduce frequency and optimize resource usage.
